### PR TITLE
Quick Fixed window cap on tiled layout (MAX 23)

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -70,6 +70,11 @@
 #include "config.h"
 #include "keybinds.h"
 
+/* Window limit occurs of 23 on 15 for some reason????? */
+#if CFG_GAP_PX == 15
+#define CFG_GAP_PX 16
+#endif
+
 /* extern var declarations */
 
 int running = 1;


### PR DESCRIPTION
For some reason when ever the number 15 was used in config it would break. No Idea why
NOTE: Not able to replicate on Xephyr.